### PR TITLE
hide header if no rows exist yet

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -3,7 +3,7 @@
     <template slot="field">
       <div class="flex flex-col">
         <!-- Title columns -->
-        <div class="simple-repeatable-header-row flex border-b border-40 py-2">
+        <div v-if="rowField.length" class="simple-repeatable-header-row flex border-b border-40 py-2">
           <div v-for="(rowField, i) in fields" :key="i" class="font-bold text-90 text-md w-full ml-3 flex">
             {{ rowField.name }}
 


### PR DESCRIPTION
might not be the best way to do this, but right now if there's no rows it shows an empty header space with a border line